### PR TITLE
docs: fix plugin install command + document update/release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ A NeurIPS 2024 oral paper proved a causal link between self-recognition and self
 ```bash
 # In Claude Code:
 /plugin marketplace add florian23/superflowers
-/plugin install superflowers@florian23-superflowers
+/plugin install superflowers@superflowers-marketplace
 ```
+
+The marketplace is registered under the `name` field of `.claude-plugin/marketplace.json`
+(`superflowers-marketplace`), not under the GitHub slug — that's why the install target is
+`superflowers@superflowers-marketplace`.
 
 ### Local Development
 
@@ -63,6 +67,32 @@ claude --plugin-dir /path/to/superflowers
 ### Verify
 
 Start a new Claude Code session. Skills should load with the `superflowers:` prefix.
+
+### Updating
+
+```bash
+# Refresh the marketplace catalog, then update the plugin:
+/plugin marketplace update superflowers-marketplace
+/plugin update superflowers@superflowers-marketplace
+```
+
+You can also enable automatic updates per marketplace via `/plugin` → **Marketplaces** →
+**Enable auto-update**.
+
+> Note: Claude Code only surfaces an update when the plugin's version identifier changes.
+> Superflowers uses explicit SemVer (see [Releasing](#releasing) below), so a new version is
+> only offered after the `version` field has been bumped.
+
+### Releasing
+
+Superflowers follows explicit SemVer, mirroring upstream `obra/superpowers`. To publish an update:
+
+1. Bump `version` in **both** `.claude-plugin/plugin.json` and the plugin entry in
+   `.claude-plugin/marketplace.json` — keep them in sync.
+2. Commit, tag (`git tag vX.Y.Z`), and push (`git push --tags`).
+
+**Pitfall:** Commits pushed *without* a version bump produce no visible update for installed
+users — Claude Code compares the `version` identifier, not the latest commit.
 
 ## The Complete Workflow
 

--- a/docs/superflowers/upstream-tracking.md
+++ b/docs/superflowers/upstream-tracking.md
@@ -55,6 +55,33 @@ obra/superpowers has a 96% PR rejection rate. Understanding why informs how we d
 - During upstream-sync: **skip skill rewrites** unless they fix a demonstrable bug — upstream tunes skills through extensive eval, not theory
 - If contributing upstream: target `dev` branch, one bug per PR, fill the PR template completely, provide test evidence
 
+## Plugin Versioning & Releasing
+
+Superflowers is installed and updated via the Claude Code plugin/marketplace mechanism:
+
+- **Install:** `/plugin marketplace add florian23/superflowers` → `/plugin install superflowers@superflowers-marketplace`
+- **Marketplace name** comes from the `name` field in `.claude-plugin/marketplace.json`
+  (`superflowers-marketplace`), *not* the GitHub slug.
+
+**Versioning strategy:** explicit SemVer, mirroring upstream `obra/superpowers` (currently `5.1.0`).
+The `version` field lives in **two** places and must stay in sync:
+
+- `.claude-plugin/plugin.json` → `version`
+- `.claude-plugin/marketplace.json` → `plugins[].version` (entry for `superflowers`)
+
+**Release procedure:**
+
+1. Bump `version` in both files (keep identical).
+2. Commit, then `git tag vX.Y.Z` and `git push --tags`.
+
+**Pitfall (why we don't use commit-SHA versioning):** Claude Code compares the `version`
+identifier to detect updates. Commits pushed *without* a version bump produce **no visible update**
+for installed users. The trade-off vs. the "drop `version` → every commit is an update" approach is
+deliberate: explicit SemVer gives release control and stays aligned with upstream's scheme.
+
+> Note: upstream version bumps (e.g. v5.0.7) are skipped during sync — they version
+> obra/superpowers, not this fork. Our `version` is independent.
+
 ## Sync History
 
 - **2026-04-03:** Sync to v5.0.7 (12 upstream commits)


### PR DESCRIPTION
## Context

Check ergab: Superflowers ist bereits vollständig als Claude-Code-Plugin/Marketplace strukturiert und auf GitHub veröffentlicht. Zwei Lücken blockierten aber „installieren & kontinuierlich updaten" — diese behebt der PR.

## Änderungen

- **README**: Install-Befehl korrigiert → `superflowers@superflowers-marketplace` (der Marketplace wird unter dem `name`-Feld der `marketplace.json` registriert, nicht unter dem GitHub-Slug). Der alte `@florian23-superflowers`-Befehl wäre fehlgeschlagen.
- **README**: neue Sektionen **Updating** und **Releasing** (SemVer-Bump in beiden Manifesten + Git-Tag).
- **upstream-tracking.md**: Versionierungs-Strategie dokumentiert (explizites SemVer wie Upstream) inkl. Stolperstein *„Commits ohne Versions-Bump → kein sichtbares Update"*.

## Verifikation

```
/plugin marketplace add florian23/superflowers
/plugin install superflowers@superflowers-marketplace
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)