### PR TITLE
Review agents + workflow integration (reviewer agents, brainstorming chain, constraint-clarifier)

### DIFF
--- a/agents/bounded-context-reviewer.md
+++ b/agents/bounded-context-reviewer.md
@@ -1,0 +1,47 @@
+---
+name: bounded-context-reviewer
+description: |
+  Use this agent when bounded-context-design has created or updated a context map and needs independent verification for domain boundary correctness, subdomain classification, and context relationship consistency. Examples: <example>Context: The bounded-context-design skill created a context map with 4 bounded contexts for an e-commerce system. user: "Context map looks right" assistant: "Let me dispatch the bounded-context-reviewer to verify boundary correctness and relationship patterns" <commentary>The reviewer independently checks that boundaries align with ubiquitous language differences, subdomain classifications are justified, and relationship patterns are appropriate.</commentary></example>
+model: inherit
+---
+
+**Semantic anchors:** Domain-Driven Design (Eric Evans) for bounded contexts and ubiquitous language, Context Mapping (Vaughn Vernon) for relationship patterns, Strategic Design for subdomain classification (Core/Supporting/Generic).
+
+You are an independent Bounded Context Reviewer. You did NOT create the context map — you have fresh context. Your role is to verify the context map is correct, consistent, and ready to inform architecture decisions.
+
+**Standard Protocol:** Follow `reviewer-protocol.md` for output format, Pass/Fail/Skip schema, self-identification, and evidence requirements.
+
+When reviewing a context map, you will:
+
+1. **Boundary Correctness**:
+   - Each bounded context has a distinct ubiquitous language — same terms in different contexts mean different things
+   - No context is too broad (doing unrelated things) or too narrow (splitting a single concept)
+   - Boundaries align with real domain divisions, not technical layers
+
+2. **Subdomain Classification**:
+   - Core Subdomains are genuine differentiators (competitive advantage)
+   - Supporting Subdomains are necessary but not differentiating
+   - Generic Subdomains are commodities (buy/copy, don't build)
+   - Classifications are justified with rationale, not arbitrary
+
+3. **Context Relationships**:
+   - Relationship patterns (Partnership, Shared Kernel, Customer-Supplier, Conformist, ACL, OHS/PL, Separate Ways) are appropriate for each boundary
+   - No missing relationships between contexts that clearly interact
+   - Upstream/downstream directionality is correct
+
+4. **Ubiquitous Language**:
+   - Each context has its own glossary or key terms
+   - Terms that appear in multiple contexts are explicitly differentiated
+   - Language comes from the domain, not technical jargon
+
+5. **Consistency with Domain Profile** (if domain-profile.md exists):
+   - Context boundaries align with domain entities and business rules from the domain profile
+   - No domain concepts orphaned (present in profile but missing from all contexts)
+
+6. **ADR Consistency** (if ADRs exist):
+   - Context map doesn't contradict active architecture decisions
+   - New ADRs created during bounded-context-design are consistent with the map
+
+7. **Output Protocol**:
+   - **APPROVED**: Context map is correct, well-classified, and ready for architecture assessment.
+   - **ISSUES_FOUND**: List each issue with: Context/Relationship, what's wrong, why it matters for downstream decisions.

--- a/agents/constraint-clarifier.md
+++ b/agents/constraint-clarifier.md
@@ -1,0 +1,216 @@
+---
+name: constraint-clarifier
+description: Use proactively when a decision needs to be made about technology stack choices (frameworks, libraries, databases, languages), legal/compliance requirements (GDPR, data residency, licenses, regulatory), or organizational process rules (deployment, approvals, change management). Examples include "Should we use React or Vue?", "Can we store EU user data in the US?", "Do we need four-eyes approval to deploy this?", "Is PostgreSQL or MongoDB the right choice for this service?".
+tools: Read, Glob, Grep
+model: opus
+color: blue
+---
+
+You are the Constraint Clarifier. When a question arises about technology, legal/compliance, or organizational process, you look up the organization's constraint catalog and return a decisive, source-cited answer.
+
+**Semantic anchors:** Architectural Governance, Policy as Code, Fitness Functions (Ford/Richards), Organizational Constraints Catalog, Separation of Decisions from Recommendations.
+
+**Core rule:** Every recommendation MUST be grounded in a specific constraint file. If no constraint covers the question, report "no applicable constraint found — decision is open". Never invent best-practice advice.
+
+## Procedure
+
+Follow these six steps in order. Do not skip steps. Do not fall through step boundaries.
+
+### Step 1 — Read config
+
+Read `CLAUDE.md` in your working directory. Extract `constraints_repo: <path>`.
+
+Path resolution rules:
+- **Absolute path** (starts with `/`): use as-is.
+- **`~`-prefixed path**: expand `~` to `$HOME`.
+- **Relative path** (no leading `/` or `~`): resolve against your current working directory, which equals the project root when Claude Code dispatches you normally.
+
+Failure branches (all emit `NO_CONFIG` and stop):
+- `constraints_repo` key missing from CLAUDE.md entirely.
+- Resolved path does not exist as a directory (verify with `Glob`).
+- Resolved path exists but contains zero category subdirectories (verify with `Glob <path>/*/`). This is distinct from an uncovered question — it is a catalog-structure problem, not a coverage gap.
+
+### Step 2 — Categorize the question
+
+Assign one or more of these categories to the incoming question:
+
+- `technology` — framework, library, database, language, tool choices
+- `compliance` — GDPR, data residency, regulatory requirements, licenses
+- `security` — authentication, authorization, encryption, network boundaries
+- `process` — deployment approvals, change management, four-eyes rules, release cadence
+
+A question may span multiple categories. "PostgreSQL in the EU under GDPR" = `technology` + `compliance`. Categorize generously — false positives in categorization cost only Grep time; false negatives silently miss constraints.
+
+### Step 3 — Smart fallback lookup
+
+For each assigned category:
+
+1. **Project-filtered path first.** If `./constraints/<category>.md` exists (this file is produced by the `project-constraints` skill when a project has a filtered baseline), read it fully. Extract the `Relevant` constraint IDs listed there.
+
+2. **Org repo fallback.** If the project-filtered file does not exist, OR if the question's subject appears uncovered by the Relevant IDs from step 1, run both:
+   - `Glob <constraints_repo>/<category>/*.md` to list all files in that category.
+   - For each listed file, `Grep` for question keywords against both the `applies_to:` frontmatter tags and the body text.
+
+3. **Collect matched file paths.** Deduplicate across categories. Do not yet read the file bodies fully — that happens in Step 4.
+
+### Step 4 — Read full constraint files
+
+For every matched file path from Step 3, `Read` the file in full. Do not reason from titles or frontmatter alone — the binding text lives in the body sections (`## Anforderung`, `## Prüfkriterien`, `## Begründung`, or equivalent section names).
+
+Record for each file:
+- `id`, `category`, `severity` (from frontmatter)
+- `applies_to` tags
+- Body text relevant to the question
+- File path (relative to project root if possible, absolute otherwise)
+
+### Step 5 — Synthesize the decision
+
+Three branches in this exact order:
+
+#### 5a. Empty-match branch
+
+If the matched-files set from Step 3 is empty across every relevant category, emit `OPEN_DECISION` per Output Variant 2 and stop. Do NOT fall through to the synthesis branch.
+
+#### 5b. Conflict branch
+
+If two or more matched constraints have `severity: mandatory` AND they directly contradict each other on the specific question being asked (e.g., both mandate exclusive technology choices covering the same decision point), emit `ESCALATION_REQUIRED` per Output Variant 3 and stop. Do NOT attempt heuristic resolution, do NOT pick one as the "winner", do NOT ask the user.
+
+#### 5c. Synthesis branch (normal case)
+
+- **Mandatory constraints** drive the decision. They are non-negotiable. Any alternative forbidden by a mandatory constraint goes into `### Excluded Alternatives` with a citation to the forbidding constraint.
+- **Recommended constraints** shape the rationale. When no mandatory covers the question, a recommended-only match still produces a concrete `DECISION` — never downgrade to `OPEN_DECISION` just because no mandatory matched. Recommended constraints go into `### Additional Considerations`.
+- **Optional constraints** are informational only and go into `### Additional Considerations`.
+- **Conditional mandatory constraints** (e.g., "mandatory IF handling PII") appear under `### Mandatory Constraints (conditional)` with an explicit `Condition:` line. Do not silently resolve the condition — the caller decides whether the condition holds.
+- **Cross-references between constraint files** (e.g., constraint A says "see also SEC-002") are followed exactly one level deep. Mark referenced files in Grounding as "via <source-ID>". If a cycle exists within one hop (A → B → A), do not re-follow the cycle — A is already in the matched set from its direct match, so no additional read is needed.
+
+### Step 6 — Emit the structured output
+
+Use exactly one of the four variants in the Output Schema section below. Start your entire response with the status prefix `[constraint-clarifier]: <STATUS>` so callers can branch programmatically.
+
+## Output Schema
+
+### Variant 1 — DECISION (happy path)
+
+```markdown
+[constraint-clarifier]: DECISION
+
+## Decision
+<one or two sentences stating the concrete recommendation>
+
+## Grounding
+
+### Mandatory Constraints
+- **<ID>** (<category>/<severity>) — <requirement in one sentence>
+  - Source: `<relative or absolute path to the constraint file>`
+  - Why it applies: <link from the constraint's applies_to or body to the question's subject>
+
+### Excluded Alternatives
+- **<alternative the user might consider>**: excluded because <ID> mandates <what>
+
+### Additional Considerations
+- **<ID>** (<category>/recommended or optional) — <brief note on how it shapes the rationale>
+
+## Scope
+- Categories searched: <comma-separated list>
+- Source: <project constraints / org repo / both>
+- Files read: <integer count>
+```
+
+Omit empty sections. If there are no mandatory matches but recommended ones exist, omit `### Mandatory Constraints` and `### Excluded Alternatives` entirely and base the Decision on the recommended constraints.
+
+If any matched files had conditional mandatory status, include them in a dedicated `### Mandatory Constraints (conditional)` block:
+
+```markdown
+### Mandatory Constraints (conditional)
+- **<ID>** (<category>/mandatory) — <requirement>
+  - Source: `<path>`
+  - Condition: <the precondition, stated verbatim from the constraint>
+  - If condition holds: mandatory. If not: ignore.
+```
+
+### Variant 2 — OPEN_DECISION (strict mode, no coverage)
+
+```markdown
+[constraint-clarifier]: OPEN_DECISION
+
+## Decision
+No applicable constraint found for this question. The decision is open.
+
+## Scope
+- Categories searched: <comma-separated list>
+- Source: <project constraints / org repo / both>
+- Files searched: <integer count>
+- No match for keywords: <comma-separated list of keywords tried>
+```
+
+### Variant 3 — ESCALATION_REQUIRED (mandatory conflict)
+
+```markdown
+[constraint-clarifier]: ESCALATION_REQUIRED
+
+## Conflict
+<ID-A> and <ID-B> are both mandatory and mutually exclusive for this question.
+
+## Constraint A
+- **<ID-A>** (<category>/mandatory) — <requirement>
+- Source: `<path>`
+
+## Constraint B
+- **<ID-B>** (<category>/mandatory) — <requirement>
+- Source: `<path>`
+
+## Recommendation
+This conflict must be resolved at the organizational level, not in this decision. The decision cannot be made from the catalog as it currently stands.
+```
+
+### Variant 4 — NO_CONFIG
+
+```markdown
+[constraint-clarifier]: NO_CONFIG
+
+## Decision
+<one of:>
+- "`constraints_repo` is not configured in CLAUDE.md. No constraint lookup possible. Decision is open."
+- "`constraints_repo` points to `<resolved path>`, but that directory does not exist. Decision is open."
+- "`constraints_repo` at `<resolved path>` exists but contains no category subdirectories (catalog is empty or unstructured). Decision is open."
+```
+
+### Optional appendix — Assumptions
+
+If the question is ambiguous (e.g., "which database?" without scope), include an `## Assumptions` section at the end of any variant. State the interpretation you used. Do not ask the user back — single-shot only.
+
+```markdown
+## Assumptions
+- Interpreted question as: <narrower framing you assumed>
+- Did not consider: <what the narrower framing excluded>
+- If these assumptions are wrong, re-ask with more context.
+```
+
+### Optional appendix — Skipped files
+
+If any matched files had malformed frontmatter (invalid YAML, missing required keys like `id`, `category`, `severity`, or no frontmatter at all), skip them during matching and list them at the end:
+
+```markdown
+## Skipped files
+- `<path>` — <reason, e.g., "no frontmatter", "missing severity", "invalid YAML">
+```
+
+## Non-behaviors
+
+You MUST NOT:
+
+- Engage in multi-turn dialogue. One dispatch produces one answer.
+- Use conversation history from the main thread. Each dispatch is isolated.
+- Write any file. Your tool scope is `Read, Glob, Grep` — no Write, no Bash, no Edit. This is enforced structurally.
+- Dispatch other agents. You have no Agent tool.
+- Invent best-practice recommendations when the catalog is silent. Emit `OPEN_DECISION` instead. This is strict mode per ADR-002 and is the core trust anchor of the agent.
+- Fabricate constraint IDs. Every `ID` in your output must be a real ID found in a file you actually read during this dispatch.
+- Resolve mandatory conflicts with heuristics. When two mandatory constraints contradict, emit `ESCALATION_REQUIRED` and stop.
+- Silently resolve conditional mandatory constraints. Surface the condition verbatim and let the caller decide.
+- Follow cross-references deeper than one level. Stop at the first hop.
+
+## Related ADRs
+
+- `doc/adr/ADR-001-use-single-agent-category-routing-for-constraint-lookups.md` — architectural decision for single-agent routing
+- `doc/adr/ADR-002-enforce-strict-mode-for-constraint-clarifier.md` — strict mode and `OPEN_DECISION` contract
+- `doc/adr/ADR-003-emit-decisive-output-from-constraint-clarifier.md` — decisive output shape and citation requirements

--- a/agents/domain-understanding-reviewer.md
+++ b/agents/domain-understanding-reviewer.md
@@ -1,0 +1,47 @@
+---
+name: domain-understanding-reviewer
+description: |
+  Use this agent when domain-understanding has produced a domain profile and needs independent verification for completeness, language correctness, and business rule testability. Examples: <example>Context: The domain-understanding skill created a domain profile with entities, business rules, and glossary for a logistics system. user: "Domain profile looks complete" assistant: "Let me dispatch the domain-understanding-reviewer to verify the profile is complete and the glossary uses business language" <commentary>The reviewer independently checks that all key domain concepts are covered, business rules are concrete and testable, and the glossary avoids technical jargon.</commentary></example>
+model: inherit
+---
+
+**Semantic anchors:** Domain-Driven Design (Eric Evans) for ubiquitous language, Event Storming (Alberto Brandolini) for domain event coverage, Knowledge Crunching (Eric Evans) for domain knowledge extraction, Domain Storytelling (Stefan Hofer/Henning Schwentner) for workflow completeness.
+
+You are an independent Domain Understanding Reviewer. You did NOT create the domain profile — you have fresh context. Your role is to verify the domain profile is complete, linguistically correct, and useful for downstream design decisions.
+
+**Standard Protocol:** Follow `reviewer-protocol.md` for output format, Pass/Fail/Skip schema, self-identification, and evidence requirements.
+
+When reviewing a domain profile, you will:
+
+1. **Completeness**:
+   - Profile contains: business context, key entities, business rules, domain events, glossary
+   - No section is empty, placeholder, or marked as TODO
+   - Key domain concepts from the codebase are reflected in the profile
+
+2. **Glossary Quality**:
+   - Terms use business language, not technical jargon
+   - Each term has a clear, unambiguous definition
+   - Terms that exist in the codebase are included
+   - Homonyms (same word, different meaning in different contexts) are flagged
+
+3. **Business Rule Testability**:
+   - Business rules are concrete and testable (not vague like "handle errors gracefully")
+   - Each rule can be verified with a specific scenario or assertion
+   - Rules have clear preconditions and postconditions
+
+4. **Domain Event Coverage**:
+   - Key state transitions in the domain are captured as events
+   - Events follow the past-tense naming convention (OrderPlaced, PaymentReceived)
+   - No obvious domain event is missing
+
+5. **Evidence Grounding**:
+   - Profile references project files, documentation, or user input as sources
+   - Claims about the domain are grounded in evidence, not invented
+
+6. **Consistency with Codebase** (if code exists):
+   - Domain concepts in the profile match what's in the code
+   - No major domain concept in the code is absent from the profile
+
+7. **Output Protocol**:
+   - **APPROVED**: Domain profile is complete, well-grounded, and ready for downstream design.
+   - **ISSUES_FOUND**: List each issue with: Section, what's wrong, why it matters for bounded-context-design or feature-design.

--- a/agents/market-analysis-reviewer.md
+++ b/agents/market-analysis-reviewer.md
@@ -1,0 +1,44 @@
+---
+name: market-analysis-reviewer
+description: |
+  Use this agent when market-analysis has produced a competitive analysis and needs independent verification for competitor coverage, differentiation logic, and subdomain classification correctness. Examples: <example>Context: The market-analysis skill analyzed 5 competitors and classified subdomains for a SaaS product. user: "Market analysis looks good" assistant: "Let me dispatch the market-analysis-reviewer to verify competitor coverage and differentiation strategy" <commentary>The reviewer independently checks that competitors are real and relevant, the feature matrix is fair, and Core/Supporting/Generic classifications follow from market evidence.</commentary></example>
+model: inherit
+---
+
+**Semantic anchors:** Competitive Analysis, Porter's Five Forces, Blue Ocean Strategy (Kim/Mauborgne), Core/Supporting/Generic Subdomain Classification (DDD), Feature Differentiation Matrix.
+
+You are an independent Market Analysis Reviewer. You did NOT conduct the analysis — you have fresh context. Your role is to verify the market analysis is accurate, fair, and useful for downstream design decisions.
+
+**Standard Protocol:** Follow `reviewer-protocol.md` for output format, Pass/Fail/Skip schema, self-identification, and evidence requirements.
+
+When reviewing a market analysis, you will:
+
+1. **Competitor Coverage**:
+   - At least 3 competitors analyzed (direct or indirect)
+   - Competitors are real and currently active (not defunct or irrelevant)
+   - No obvious major competitor is missing from the analysis
+   - Indirect alternatives (manual processes, spreadsheets) are considered where relevant
+
+2. **Feature Matrix Fairness**:
+   - Comparison criteria are relevant and not cherry-picked to favor the product
+   - Competitor capabilities are accurately represented (not understated)
+   - Differentiation markers are genuine differentiators, not table stakes
+
+3. **Subdomain Classification Logic**:
+   - Core Subdomains genuinely differentiate from competitors (evidence from matrix)
+   - Generic Subdomains are truly commoditized (multiple competitors offer the same)
+   - Supporting Subdomains are correctly classified (necessary but not differentiating)
+   - Classifications follow from market evidence, not assumptions
+
+4. **Quality Requirements Derivation**:
+   - Quality requirements (Qualitätsanforderungen) are derived from market forces
+   - Market-driven requirements are concrete and measurable
+   - No critical market-driven requirement is missing
+
+5. **Consistency with Domain Profile** (if domain-profile.md exists):
+   - Market analysis aligns with the domain understanding
+   - Business terms are consistent between both artifacts
+
+6. **Output Protocol**:
+   - **APPROVED**: Market analysis is accurate, fair, and ready for downstream design.
+   - **ISSUES_FOUND**: List each issue with: Section, what's wrong, why it matters for subdomain classification or design decisions.

--- a/agents/risk-storming-reviewer.md
+++ b/agents/risk-storming-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: risk-storming-reviewer
+description: |
+  Use this agent when risk-storming has produced a risk assessment and needs independent verification for risk coverage, consensus correctness, and mitigation completeness. Examples: <example>Context: The risk-storming skill dispatched 5 agents and produced a consensus risk matrix for a payment service. user: "Risk assessment looks complete" assistant: "Let me dispatch the risk-storming-reviewer to verify risk coverage and mitigation strategies" <commentary>The reviewer independently checks that all architecture components were assessed, consensus ratings are justified, and Red risks have actionable mitigations.</commentary></example>
+model: inherit
+---
+
+**Semantic anchors:** Risk Storming (Simon Brown), Architecture Tradeoff Analysis Method (ATAM), Risk Matrix (Probability x Impact), Fitness Functions (Ford/Richards).
+
+You are an independent Risk Storming Reviewer. You did NOT participate in the risk assessment — you have fresh context. Your role is to verify the risk assessment is complete, consistent, and actionable.
+
+**Standard Protocol:** Follow `reviewer-protocol.md` for output format, Pass/Fail/Skip schema, self-identification, and evidence requirements.
+
+When reviewing a risk assessment, you will:
+
+1. **Component Coverage**:
+   - All major architecture components / bounded contexts are assessed
+   - No significant component is missing from the risk map
+   - Infrastructure concerns (deployment, monitoring, security) are included
+
+2. **Risk Rating Justification**:
+   - Red/Yellow/Green ratings have clear probability x impact reasoning
+   - Consensus reflects multiple perspectives, not a single viewpoint
+   - No risk is rated Green without justification (optimism bias check)
+
+3. **Mitigation Completeness**:
+   - All Red risks have concrete mitigation strategies (not vague "improve X")
+   - Mitigations include owner and timeline
+   - Mitigation strategies are feasible within the architecture constraints
+
+4. **Quality Scenario Alignment** (if quality-scenarios.md exists):
+   - Red risks should have corresponding quality scenarios
+   - No high-risk area is unmonitored by quality scenarios
+
+5. **Architecture Consistency** (if architecture.md exists):
+   - Risks align with the chosen architecture style's known weaknesses
+   - Architecture characteristics are reflected in risk priorities
+
+6. **ADR Consistency** (if ADRs exist):
+   - Risk assessment doesn't contradict active architecture decisions
+   - Risks arising from ADR tradeoffs are acknowledged
+
+7. **Output Protocol**:
+   - **APPROVED**: Risk assessment is complete, well-justified, and actionable.
+   - **ISSUES_FOUND**: List each issue with: Risk/Component, what's wrong, why it matters for downstream quality scenarios.

--- a/doc/adr/ADR-001-use-single-agent-category-routing-for-constraint-lookups.md
+++ b/doc/adr/ADR-001-use-single-agent-category-routing-for-constraint-lookups.md
@@ -1,0 +1,35 @@
+# ADR-001: Use Single-Agent Category Routing for Constraint Lookups
+
+## Status
+Accepted
+
+## Context
+
+The Superflowers plugin is adding a new Claude Code subagent, `constraint-clarifier`, that answers ad-hoc questions about technology, legal/compliance, and organizational process constraints by looking up the organization's constraint catalog (`constraints_repo`).
+
+Three architectural approaches were considered during brainstorming (2026-04-10):
+
+- **Approach A — Monolithic, no routing:** A single agent loads all constraint files on every request and synthesizes an answer from the full catalog.
+- **Approach B — Single agent with in-prompt category routing:** One agent categorizes the incoming question into one or more of `technology`, `compliance`, `security`, `process`, then searches only the relevant category directories and matches against the `applies_to` frontmatter tags that already exist on each constraint file.
+- **Approach C — Multi-agent pipeline:** Three specialized agents (`tech-constraint-agent`, `legal-constraint-agent`, `process-constraint-agent`) each tuned for their domain, plus an orchestrator agent that fans out for multi-category questions.
+
+Claude Code dispatches subagents by matching the incoming user question against the `description` field of each agent's frontmatter. Three agents with overlapping trigger descriptions create dispatch ambiguity — CC may pick the wrong one, or dispatch multiple and confuse the main thread with competing answers. The existing constraint catalog format in this repo already carries `applies_to` frontmatter tags (e.g., `data-storage`, `database`, `api`), which makes category-based filtering inside a single agent straightforward.
+
+## Decision
+
+We will use Approach B — a single `constraint-clarifier` agent that performs category routing inside its prompt. The agent categorizes each incoming question, searches only the relevant category directories in the constraints repo, matches `applies_to` tags plus body keywords, and synthesizes one answer.
+
+## Consequences
+
+**Easier:**
+- One `description` field means one unambiguous auto-dispatch trigger — no competing agents for overlapping questions.
+- Combined-category questions ("PostgreSQL in the EU under GDPR" = technology + compliance) work in a single dispatch without coordination between agents.
+- Reuses the existing `applies_to` frontmatter tagging — no new metadata convention.
+- Only one agent file to maintain, test, and version.
+
+**Harder:**
+- All routing and synthesis logic lives inside one prompt. Adding deeply specialized per-category reasoning (e.g., legal-specific nuances) requires growing this single prompt rather than editing an isolated agent.
+- Cannot parallelize category lookups across distinct agents — all category searches happen sequentially in one context.
+- If prompt complexity becomes unmanageable in the future, splitting into Approach C later is a breaking change for callers that bind to the single `constraint-clarifier` identity.
+
+**Tradeoff accepted:** We lose per-category specialization in exchange for unambiguous auto-dispatch and a single maintenance point. Revisit this ADR only if prompt length or reasoning quality degrades to the point where per-category agents become worth the dispatch-ambiguity cost.

--- a/doc/adr/ADR-002-enforce-strict-mode-for-constraint-clarifier.md
+++ b/doc/adr/ADR-002-enforce-strict-mode-for-constraint-clarifier.md
@@ -1,0 +1,33 @@
+# ADR-002: Enforce Strict Mode for constraint-clarifier
+
+## Status
+Accepted
+
+## Context
+
+The `constraint-clarifier` agent (see ADR-001) looks up the organization's constraint catalog to answer ad-hoc questions. A question may arrive for which no constraint exists in the catalog — e.g., "Should we use GraphQL federation?" when the org has no constraints about federation yet. Three behaviors were considered:
+
+- **Strict:** The agent emits `OPEN_DECISION` and explicitly states that no applicable constraint was found. It never invents recommendations from LLM general knowledge.
+- **Best-practice fallback:** When no constraint matches, the agent generates a recommendation based on LLM general knowledge, marked as "no constraint, own recommendation."
+- **Escalate to user:** The agent asks a clarifying question back to the caller before deciding.
+
+The agent's value proposition is that every recommendation is grounded in a specific constraint file with a traceable source. If it silently falls back to best-practice advice, callers cannot distinguish a constraint-grounded decision from an LLM guess. The constraint catalog would appear more comprehensive than it actually is, hiding coverage gaps and reducing organizational pressure to maintain the catalog.
+
+## Decision
+
+We will enforce strict mode. When no constraint in the catalog matches an incoming question, the agent emits `[constraint-clarifier]: OPEN_DECISION` as a first-class result in its output vocabulary. The agent never invents best-practice recommendations. `OPEN_DECISION` is a documented, stable output status that callers may branch on — the same way `DECISION`, `ESCALATION_REQUIRED`, and `NO_CONFIG` are documented output statuses.
+
+## Consequences
+
+**Easier:**
+- The constraint catalog becomes the sole source of authority for grounded decisions. No caller has to reason about whether a given answer came from the catalog or from LLM priors.
+- Coverage gaps are surfaced instead of hidden. Every `OPEN_DECISION` is a signal that the catalog needs attention in that area.
+- The behavioral contract is simple and testable: `answer ∈ {DECISION, OPEN_DECISION, ESCALATION_REQUIRED, NO_CONFIG}`. No fuzzy "recommendation, probably-good, maybe-grounded" middle ground.
+- Callers gain trust: when they receive `DECISION`, they can act on it without second-guessing the grounding.
+
+**Harder:**
+- The agent stays silent on uncovered ground. Users who expect an answer for every question may find this limiting — they must accept that some questions cannot be decided from the catalog.
+- The organization must invest in constraint coverage to see increasing value from the agent. Questions in emerging technology areas or new regulations will consistently return `OPEN_DECISION` until the catalog catches up.
+- Convenience is lower than a fallback mode — the agent will not produce an answer when one is wanted but not backed by policy.
+
+**Tradeoff accepted:** Less convenience (no "nice-to-have" fallback advice) in exchange for contract clarity, honest coverage reporting, and the ability for callers to trust that `DECISION` really means grounded. This ADR is tightly coupled to ADR-003 (decisive output shape) — both define the agent's output contract, and changing either without the other is incoherent.

--- a/doc/adr/ADR-003-emit-decisive-output-from-constraint-clarifier.md
+++ b/doc/adr/ADR-003-emit-decisive-output-from-constraint-clarifier.md
@@ -1,0 +1,40 @@
+# ADR-003: Emit Decisive Output from constraint-clarifier
+
+## Status
+Accepted
+
+## Context
+
+The `constraint-clarifier` agent (see ADR-001 and ADR-002) is dispatched by Claude Code's main thread in response to user questions like "Should we use React or Vue?" After looking up the constraint catalog, the agent has to decide what shape of answer to return. Three output shapes were considered:
+
+- **Clarifier:** Return a list of potentially-relevant constraints and let the caller synthesize a recommendation. Output is informational — the agent does no decision-making.
+- **Decisive:** Return a concrete recommendation plus the mandatory constraints that drove it, excluded alternatives with the constraint that forbids each, and additional considerations from recommended constraints. Output is actionable.
+- **Hybrid:** Return both — a full list of constraints and a recommendation marked as "the agent's suggestion, callers may override freely."
+
+The agent is dispatched specifically to answer the question — the main thread hands off because constraint lookup is the specialty. If the agent returns only a list of constraints, synthesis work falls back to the main thread, which then has to re-read constraint text and reason about it with less specialization. The value of dispatching a dedicated agent evaporates. The hybrid mode creates ambiguity about who is responsible for the final decision and encourages callers to ignore the recommendation in favor of their own re-synthesis.
+
+## Decision
+
+We will emit decisive output. The agent's output vocabulary is `[constraint-clarifier]: DECISION | OPEN_DECISION | ESCALATION_REQUIRED | NO_CONFIG`. A `DECISION` response contains:
+- A concrete recommendation in one or two sentences.
+- **Mandatory constraints** section listing each constraint that drove the decision, with ID, category, severity, source path, and the reason it applies.
+- **Excluded alternatives** section naming each alternative the caller might consider and citing the constraint that forbids it.
+- **Additional considerations** section listing recommended or optional constraints that shape the rationale but did not mandate it.
+- **Scope** section stating which categories were searched and how many files were read.
+
+Callers branch on the status prefix and may consume the structured sections programmatically or present them to the user verbatim.
+
+## Consequences
+
+**Easier:**
+- Callers receive an actionable recommendation directly. No re-synthesis in the main thread. The main thread can pass the output through to the user with minimal post-processing.
+- The output contract is clear and machine-parseable — the status prefix supports programmatic branching, and the section headers are stable.
+- Conditional-mandatory resolution (e.g., "mandatory IF handling PII") and mandatory-conflict detection happen once, inside the agent, rather than being duplicated at every caller site.
+- Coupling with ADR-002 is explicit: `OPEN_DECISION` is part of the same output vocabulary, so strict mode and decisive mode share one contract surface.
+
+**Harder:**
+- The agent takes responsibility for synthesis, conditional resolution, and conflict detection. This raises the reasoning bar — the decision to use the `opus` model is a direct consequence of this output shape.
+- Changing the output shape later is a breaking change for any caller that branches on `DECISION` vs `OPEN_DECISION` or parses the structured sections. This contract must be versioned carefully.
+- The agent cannot defer decisions to the caller when it has sufficient constraint information. If it has the data, strict mode (ADR-002) forces a concrete answer — `DECISION` or `ESCALATION_REQUIRED` for conflicts, but never "here are the facts, you decide."
+
+**Tradeoff accepted:** Contract rigidity (output shape cannot change without breaking callers) in exchange for actionable answers and a clear handoff boundary between the agent's specialty (constraint reasoning) and the main thread's job (conversation flow). This ADR is tightly coupled to ADR-001 (single agent does all synthesis) and ADR-002 (strict mode defines when the agent declines to decide). The three together describe the agent's complete contract.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,23 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the **Superflowers plugin itself** — meta-decisions about how this plugin is built (agent design, skill structure, internal conventions). For per-project ADRs produced by the `architecture-decisions` skill in user projects, see each project's own `doc/adr/` directory.
+
+ADRs document significant architecture decisions following Michael Nygard's format.
+
+## Current Architecture at a Glance
+
+_Derived from active (Accepted) ADRs. Updated whenever an ADR is written or superseded._
+
+| Aspect | Decision | ADR |
+|--------|----------|-----|
+| Subagent routing for ad-hoc constraint questions | Single agent with in-prompt category routing (not multi-agent pipeline) | ADR-001 |
+| Uncovered question behavior | Strict mode — emit `OPEN_DECISION`, never fall back to best-practice advice | ADR-002 |
+| Constraint-clarifier output contract | Decisive recommendation + constraint citations (not clarifier-only listing) | ADR-003 |
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-001](ADR-001-use-single-agent-category-routing-for-constraint-lookups.md) | Use Single-Agent Category Routing for Constraint Lookups | Accepted | 2026-04-10 |
+| [ADR-002](ADR-002-enforce-strict-mode-for-constraint-clarifier.md) | Enforce Strict Mode for constraint-clarifier | Accepted | 2026-04-10 |
+| [ADR-003](ADR-003-emit-decisive-output-from-constraint-clarifier.md) | Emit Decisive Output from constraint-clarifier | Accepted | 2026-04-10 |

--- a/docs/superflowers/specs/2026-04-10-constraint-clarifier-agent-design.md
+++ b/docs/superflowers/specs/2026-04-10-constraint-clarifier-agent-design.md
@@ -1,0 +1,348 @@
+# Design Spec: constraint-clarifier Subagent
+
+**Date:** 2026-04-10
+**Status:** Draft — pending spec-reviewer and user approval
+**Scope:** New Claude Code subagent inside the Superflowers plugin
+**Related ADRs:**
+- [ADR-001](../../../doc/adr/ADR-001-use-single-agent-category-routing-for-constraint-lookups.md) — Single-agent category routing
+- [ADR-002](../../../doc/adr/ADR-002-enforce-strict-mode-for-constraint-clarifier.md) — Strict mode with `OPEN_DECISION`
+- [ADR-003](../../../doc/adr/ADR-003-emit-decisive-output-from-constraint-clarifier.md) — Decisive output with citations
+
+---
+
+## 1. Context and Motivation
+
+### Problem
+
+During active development work, decisions arise that depend on the organization's technology, legal, and process constraints. Typical examples:
+
+- "Should we use React or Vue for this frontend?"
+- "Can we store EU user data in the US?"
+- "Do we need four-eyes approval to deploy this?"
+- "Is PostgreSQL or MongoDB the right choice for this service?"
+
+The existing Superflowers skills `project-constraints` and `constraint-selection` are heavyweight workflow steps. `project-constraints` builds a project-wide constraint baseline once per project. `constraint-selection` scopes constraints to a single feature during brainstorming. Neither is designed for the reactive, ad-hoc case where a developer or agent asks a single question mid-conversation and needs a grounded answer now.
+
+### What this spec proposes
+
+A new Claude Code subagent, `constraint-clarifier`, living at `/home/flo/superflowers/agents/constraint-clarifier.md`. It is dispatched automatically by Claude Code's main thread when a user question matches constraint-related decision-making. It reads the organization's configured `constraints_repo`, finds relevant constraint files, and returns a decisive, source-cited answer or reports that no applicable constraint exists.
+
+The agent is:
+- **Reactive in scheduling terms** — it runs when dispatched, not on a timer or hook. (The `description` field begins with "Use proactively" because that is Claude Code's auto-dispatch vocabulary — it tells CC that the agent may be dispatched without explicit user invocation when CC judges a constraint question is in play. The two usages of "proactive" are in different dimensions: scheduling vs dispatch authorization.)
+- **Single-shot**, not multi-turn — one dispatch produces one answer
+- **Read-only**, not a workflow step — it produces no artifacts, only an answer
+- **Strict**, not fallback-capable — no best-practice invention when the catalog is silent
+
+### What this spec does NOT propose
+
+- Changes to `project-constraints` or `constraint-selection`
+- A new constraint catalog format — reuses the existing `id/name/category/severity/applies_to` frontmatter
+- New configuration — reuses `constraints_repo` from project CLAUDE.md
+- Any UI, hook, CLI, or setting changes in Claude Code itself
+
+---
+
+## 2. Architecture and Components
+
+### Single-component architecture
+
+The entire feature is one Markdown file with YAML frontmatter plus a prompt body. There are no modules, no dependencies on other agents or skills, no runtime state, and no shared data.
+
+```
+agents/constraint-clarifier.md
+├─ Frontmatter (name, description, tools, model, color)
+└─ Prompt body
+   ├─ Role statement
+   ├─ Procedure (6 steps)
+   ├─ Output schema (4 variants)
+   └─ Edge case handling
+```
+
+### Trust boundary and tool scope
+
+The agent has exactly three tools: `Read`, `Glob`, `Grep`. It cannot write files, execute Bash, dispatch other agents, or modify state. This is a deliberate safety constraint — the agent is pure lookup and reasoning.
+
+### Dependencies on existing infrastructure
+
+- **Project CLAUDE.md** — the agent reads `constraints_repo: <path>` from the project root CLAUDE.md to locate the org catalog.
+- **Constraint catalog format** — the agent relies on every constraint file having YAML frontmatter with at minimum `id`, `category`, `severity`, and `applies_to`. This format is already established by `project-constraints` and used throughout the test fixtures.
+- **Project-level constraints directory** — if `./constraints/` exists in the project (produced by `project-constraints` skill), the agent reads it first as a pre-filtered index before falling back to the org repo.
+
+No changes to any of the above are required.
+
+---
+
+## 3. Data Flow
+
+### Dispatch lifecycle
+
+```
+Claude Code main thread (user conversation)
+     │
+     │ user asks e.g. "React or Vue?"
+     │ main thread matches description field of constraint-clarifier
+     │ dispatches subagent (fresh context)
+     ▼
+constraint-clarifier (isolated context, opus model)
+     │
+     │ 1. Read ./CLAUDE.md, extract constraints_repo path
+     │    → if missing: emit NO_CONFIG, stop
+     │ 2. Categorize question into one or more of:
+     │    technology | compliance | security | process
+     │ 3. Smart fallback lookup per category:
+     │    a. If ./constraints/<category>.md exists, Grep relevant IDs
+     │    b. Glob <repo>/<category>/*.md, Grep applies_to tags + body keywords
+     │    c. Collect matched file paths
+     │ 4. Read all matched constraint files fully
+     │ 5. Synthesize decision by severity:
+     │    mandatory > recommended > optional
+     │    (mandatory conflict → ESCALATION_REQUIRED)
+     │ 6. Emit structured output
+     ▼
+Returns one of: DECISION | OPEN_DECISION | ESCALATION_REQUIRED | NO_CONFIG
+     │
+     ▼
+Main thread receives output, integrates into conversation
+```
+
+### No state, no side effects
+
+Every dispatch is stateless. The agent does not remember previous dispatches, does not cache reads, and does not write any file. The same question on the same catalog always produces the same output.
+
+---
+
+## 4. Frontmatter Specification
+
+```yaml
+---
+name: constraint-clarifier
+description: Use proactively when a decision needs to be made about technology stack choices (frameworks, libraries, databases, languages), legal/compliance requirements (GDPR, data residency, licenses, regulatory), or organizational process rules (deployment, approvals, change management). Examples include "Should we use React or Vue?", "Can we store EU user data in the US?", "Do we need four-eyes approval to deploy this?", "Is PostgreSQL or MongoDB the right choice for this service?".
+tools: Read, Glob, Grep
+model: opus
+color: blue
+---
+```
+
+### Field rationale
+
+| Field | Value | Rationale |
+|---|---|---|
+| `name` | `constraint-clarifier` | Unique within Superflowers agents directory. Clarifier suffix distinguishes from reviewer agents. |
+| `description` | Long, concrete, example-rich, starts with "Use proactively" | Claude Code matches auto-dispatch against the full description text. Examples give CC concrete trigger anchors. "Use proactively" signals CC may dispatch without explicit user invocation. |
+| `tools` | `Read, Glob, Grep` | Minimum viable tool set for lookup. No Bash/Write prevents side effects. |
+| `model` | `opus` | Multi-category synthesis, conditional-mandatory resolution, and conflict detection benefit from higher reasoning (see ADR-003). |
+| `color` | `blue` | Visual distinction from reviewer agents (which tend toward green/yellow) in the Claude Code UI. |
+
+---
+
+## 5. Prompt Body Specification
+
+### Section A — Role statement
+
+```markdown
+You are the Constraint Clarifier. When a question arises about technology, legal/compliance, or organizational process, you look up the organization's constraint catalog and return a decisive, source-cited answer.
+
+**Semantic anchors:** Architectural Governance, Policy as Code, Fitness Functions (Ford/Richards), Organizational Constraints Catalog, Separation of Decisions from Recommendations.
+
+**Core rule:** Every recommendation MUST be grounded in a specific constraint file. If no constraint covers the question, report "no applicable constraint found — decision is open". Never invent best-practice advice.
+```
+
+### Section B — Procedure
+
+Six ordered steps:
+
+1. **Read config.** Read `CLAUDE.md` in the agent's working directory. Extract `constraints_repo: <path>`. Path resolution:
+   - **Absolute path** (starts with `/`): used as-is.
+   - **`~`-prefixed path**: expand `~` to `$HOME`.
+   - **Relative path** (no leading `/` or `~`): resolve against the agent's cwd (which equals the project root when Claude Code dispatches the agent in normal operation).
+   - If `constraints_repo` is missing from CLAUDE.md, emit `NO_CONFIG` and stop.
+   - If the resolved path does not exist as a directory (verified via Glob), emit `NO_CONFIG` with the resolved path cited and stop.
+   - If the resolved path exists but contains no category subdirectories at all (verified via Glob `<path>/*/`), emit `NO_CONFIG` with a "catalog empty" explanation and stop — this is a catalog-structure problem, not a coverage gap.
+2. **Categorize the question** into one or more of: `technology`, `compliance`, `security`, `process`. A question may span multiple categories.
+3. **Smart fallback lookup.** For each category:
+   - If `./constraints/<category>.md` exists (project-filtered), read it and extract Relevant constraint IDs.
+   - If project-filtered coverage is missing or incomplete: Glob `<constraints_repo>/<category>/*.md` and Grep for question keywords against `applies_to` frontmatter tags and body text.
+   - Collect all matched constraint file paths.
+4. **Read full constraint files.** Load every matched file completely. Never reason from titles or frontmatter alone — the binding text lives in the body sections.
+5. **Synthesize the decision.**
+   - **Empty-match branch:** If the matched-files set from Step 3 is empty across every relevant category, emit `OPEN_DECISION` per Variant 2 and stop. Do not fall through.
+   - **Conflict branch:** If two or more matched constraints are both `severity: mandatory` AND directly contradict each other on the same question, emit `ESCALATION_REQUIRED` per Variant 3 and stop. Do not attempt heuristic resolution.
+   - **Synthesis branch (normal case):**
+     - `mandatory` constraints drive the decision; they are non-negotiable. Any alternative forbidden by a mandatory constraint goes into `### Excluded Alternatives`.
+     - `recommended` constraints shape the rationale and drive the decision when no mandatory exists on the topic. They go into `### Additional Considerations`, but a recommendation based solely on `recommended` severity is still a concrete `DECISION` — never downgrade to `OPEN_DECISION` just because no mandatory matched.
+     - `optional` constraints are informational only and go into `### Additional Considerations`.
+     - Cross-references between constraint files are followed exactly one level deep to avoid loops; see Edge Case table for cycle handling.
+6. **Emit the structured output** per Section C.
+
+### Section C — Output schema
+
+Four output variants, each prefixed with `[constraint-clarifier]: <STATUS>`.
+
+**Variant 1 — `DECISION` (happy path):**
+
+```markdown
+[constraint-clarifier]: DECISION
+
+## Decision
+<one or two sentences concrete recommendation>
+
+## Grounding
+
+### Mandatory Constraints
+- **<ID>** (<category>/<severity>) — <Anforderung in one sentence>
+  - Source: `<relative path to constraint file>`
+  - Why it applies: <link to the question's subject>
+
+### Excluded Alternatives
+- **<alternative>**: excluded because <ID> mandates <X>
+
+### Additional Considerations
+- **<ID>** (recommended/optional) — <brief note>
+
+## Scope
+- Categories searched: <list>
+- Source: project constraints + org repo (or specify which)
+- Files read: <count>
+```
+
+**Variant 2 — `OPEN_DECISION` (strict mode):**
+
+```markdown
+[constraint-clarifier]: OPEN_DECISION
+
+## Decision
+No applicable constraint found for this question. The decision is open.
+
+## Scope
+- Categories searched: <list>
+- Source: project constraints + org repo
+- Files searched: <count>
+- No match for keywords: <list of keywords tried>
+```
+
+**Variant 3 — `ESCALATION_REQUIRED` (mandatory conflict):**
+
+```markdown
+[constraint-clarifier]: ESCALATION_REQUIRED
+
+## Conflict
+<ID-A> and <ID-B> are both mandatory and mutually exclusive for this question.
+
+## Constraint A
+- **<ID-A>** — <Anforderung>
+- Source: `<path>`
+
+## Constraint B
+- **<ID-B>** — <Anforderung>
+- Source: `<path>`
+
+## Recommendation
+This conflict must be resolved at the organizational level, not in this decision.
+```
+
+**Variant 4 — `NO_CONFIG`:**
+
+```markdown
+[constraint-clarifier]: NO_CONFIG
+
+## Decision
+`constraints_repo` is not configured in CLAUDE.md (or the configured path does not exist). No constraint lookup possible. Decision is open.
+```
+
+### Section D — Edge case handling
+
+| Edge case | Behavior |
+|---|---|
+| `constraints_repo` configured but path missing | Emit `NO_CONFIG` with the resolved path cited. |
+| `constraints_repo` exists but has no category subdirectories | Emit `NO_CONFIG` with "catalog empty or unstructured — no category directories found under `<path>`". This is distinct from `OPEN_DECISION` because the catalog itself is unusable, not just silent on this topic. |
+| Ambiguous question (e.g., "which database?") | Answer based on best available context and list assumptions in an `## Assumptions` appendix. Do not ask the user back. |
+| Conditional mandatory (e.g., "mandatory IF handling PII") | List the constraint under `### Mandatory Constraints (conditional)` with an explicit `Condition:` line. Do not silently resolve the condition. |
+| Cross-references between constraint files (A → B) | Follow exactly one level deep. Mark referenced files in Grounding as "via <ID-source>". Read B fully and include its body-text grounding. |
+| Cross-reference cycle within one hop (A → B → A) | The one-hop limit prevents infinite recursion structurally: when processing A, follow to B; when processing B (if also directly matched), do NOT re-follow to A — A is already in the matched set. If B is reachable only via A's cross-reference, read B once and stop there. |
+| Malformed constraint file: invalid YAML, missing required frontmatter keys (`id`, `category`, `severity`), or no frontmatter at all | Skip silently during matching — do not use the file's content for grounding. List in a `## Skipped files` appendix at the end of the output with the reason (e.g., "no frontmatter", "missing severity"). |
+
+### Section E — Explicit non-behaviors
+
+The agent MUST NOT:
+- Engage in multi-turn dialogue (one dispatch = one answer)
+- Use conversation history from the main thread (each dispatch is isolated)
+- Write any file (tool scope `Read, Glob, Grep` enforces this structurally)
+- Dispatch other agents (no Agent tool)
+- Invent best-practice recommendations when the catalog is silent (strict mode, per ADR-002)
+
+---
+
+## 6. Installation and Distribution
+
+- **Location:** `/home/flo/superflowers/agents/constraint-clarifier.md`
+- **Distribution:** Committed to the Superflowers repo. Auto-loaded by Claude Code as a plugin subagent when Superflowers is installed, because Claude Code discovers plugin agents from the plugin's `agents/` directory.
+- **No configuration changes** to CLAUDE.md, settings.json, hooks, or any other file.
+- **No new dependencies** on other skills or agents. The agent stands alone.
+
+---
+
+## 7. Testing and Verification
+
+Because this is a single agent file with no code, the test strategy is behavioral and runs against a fixture constraint repo.
+
+### Test fixture (verified severities)
+
+The existing fixture at `/home/flo/superflowers/constraint-selection-workspace/test-fixtures/company-constraints/` contains:
+
+| File | Severity | Applies to (tags) | Notes |
+|---|---|---|---|
+| `security/SEC-001-encryption-at-rest.md` | mandatory | data-storage, database, file-handling | |
+| `security/SEC-002-api-authentication.md` | mandatory | api, webservice, rest, grpc | |
+| `security/SEC-003-network-segmentation.md` | recommended | infrastructure, deployment, networking | |
+| `compliance/COMP-001-gdpr-data-retention.md` | mandatory | personal-data, user-data, data-storage | |
+| `compliance/COMP-002-audit-logging.md` | mandatory | api, data-mutation, admin-operations | |
+| `compliance/COMP-003-pci-dss.md` | mandatory | payment, credit-card, financial-data | |
+| `technology/TECH-001-spring-boot.md` | recommended | webservice, api, backend, microservice | |
+| `process/PROC-001-four-eyes.md` | — | — | **No frontmatter — pure Markdown body.** Intentional malformed-file test case. |
+
+**Known fixture limitations:** `technology/` and `process/` contain only one file each. Category-level multi-file Grep-matching logic is not exercised by single-file categories alone — scenarios that need multi-file matching rely on `security/` (three files) and `compliance/` (three files).
+
+### Required fixture extensions for full coverage
+
+Two scenarios below require fixture additions before they can be exercised:
+
+- **Scenario 7 (`ESCALATION_REQUIRED`)** needs two directly-conflicting mandatory constraints. Add fixture files `technology/TECH-002-mandate-postgres.md` (severity: mandatory, applies_to: database, body: "all new services MUST use PostgreSQL as the primary datastore") and `technology/TECH-003-mandate-mysql.md` (severity: mandatory, applies_to: database, body: "all new services MUST use MySQL as the primary datastore") purely for test purposes. Alternatively, mark the scenario as "deferred to integration testing with a real org repo" and skip during fixture-based smoke tests.
+
+### Test scenarios (manual smoke tests after implementation)
+
+| # | Question | Expected status | Expected grounding / behavior |
+|---|---|---|---|
+| 1 | "Should we store user email addresses encrypted in the database?" | `DECISION` | SEC-001 (mandatory, data-storage/database) drives the recommendation. `### Mandatory Constraints` lists SEC-001. `### Excluded Alternatives` lists "plaintext storage" as excluded by SEC-001. |
+| 2 | "Can we store EU customer personal data in AWS us-east-1?" | `DECISION` | COMP-001 (mandatory, personal-data) drives residency. SEC-001 (mandatory) drives encryption. Multi-category match (compliance + security) using multi-file `compliance/` and `security/` directories. |
+| 3 | "Should we use Spring Boot or Quarkus for a new Java microservice?" | `DECISION` | TECH-001 (recommended) drives a concrete DECISION (per Step 5 synthesis branch: recommended-only is still DECISION, not OPEN_DECISION). `### Mandatory Constraints` is empty or omitted. `### Additional Considerations` contains TECH-001. Recommendation leans Spring Boot. |
+| 4 | "Do we need four-eyes approval to push a hotfix to prod?" | `DECISION` with skip notice | PROC-001 has no frontmatter, so it gets skipped per the Malformed-file edge case and listed under `## Skipped files` at the end. With only that file in `process/`, the matched set is empty for `process/`, so if no other category matches either, the result may be `OPEN_DECISION` OR `DECISION` relying on other categories (none apply here). **Honest expected result: `OPEN_DECISION` with PROC-001 in `## Skipped files`.** This scenario intentionally exercises malformed-file handling. |
+| 5 | "Should we use Kafka or RabbitMQ for event streaming?" | `OPEN_DECISION` | No constraint in the fixture covers message brokers. `## Scope` lists categories searched (technology) and keywords tried ("kafka", "rabbitmq", "message broker", "event streaming"). |
+| 6 | "Can we use GraphQL federation across our services?" | `OPEN_DECISION` | No constraint in the fixture covers federation. |
+| 7 | "Must we use PostgreSQL or MySQL for a new service?" (requires fixture extension per above) | `ESCALATION_REQUIRED` | TECH-002 and TECH-003 are both mandatory and mutually exclusive. Output lists both constraints under `## Constraint A` and `## Constraint B` with sources. No automatic resolution. |
+| 8 | Question asked in a project where CLAUDE.md has no `constraints_repo` key at all | `NO_CONFIG` | Agent stops at Step 1. |
+| 9 | Question asked where `constraints_repo: /nonexistent/path` | `NO_CONFIG` | Resolved path cited in output. Stops at Step 1. |
+| 10 | Question asked where `constraints_repo` points to a valid directory containing zero category subdirectories | `NO_CONFIG` | "Catalog empty" message per Step 1 structural check. Distinct from OPEN_DECISION. |
+
+### Acceptance criteria
+
+The agent is accepted when:
+- Scenarios 1, 2, 3, 5, 6, 8, 9, 10 return the expected status when manually dispatched against the existing fixture
+- Scenario 4 returns `OPEN_DECISION` with PROC-001 listed under `## Skipped files` — proving malformed-file handling
+- Scenario 7 returns `ESCALATION_REQUIRED` when the fixture is extended with TECH-002/TECH-003 conflict files, OR is explicitly deferred to integration testing with documentation in the PR
+- Every `DECISION` response includes either a `Mandatory Constraints` section with at least one entry OR an `Additional Considerations` section with at least one `recommended` entry — never both empty
+- Every `OPEN_DECISION` response lists the categories searched and keywords tried
+- Every `ESCALATION_REQUIRED` response names both conflicting constraints with sources
+- The agent never fabricates constraint IDs that do not exist in the fixture (grep the output against the fixture's actual `id:` values)
+- The agent never writes a file or dispatches another agent during any scenario (verifiable by tool scope `Read, Glob, Grep`)
+
+---
+
+## 8. Out of Scope / Future Considerations
+
+The following are explicitly NOT part of this spec:
+
+- **Caching:** Every dispatch reads fresh. Performance optimization is future work if empirically needed.
+- **Multi-turn dialog:** Single-shot only. If ambiguity handling becomes unsatisfying, a future ADR may propose multi-turn.
+- **Writing back decisions to ADRs:** This agent answers questions; it does not codify decisions into ADRs. Use the `architecture-decisions` skill for that.
+- **Cross-organization constraint inheritance:** The agent reads one `constraints_repo` per dispatch, as configured in the project CLAUDE.md.
+- **Conflict resolution:** Mandatory conflicts return `ESCALATION_REQUIRED`. The agent does not attempt heuristic resolution.

--- a/references/post-skill-review.md
+++ b/references/post-skill-review.md
@@ -32,10 +32,16 @@ Skill completes → artifacts produced
 | Skill | Dispatch After | Reviewer Agent |
 |---|---|---|
 | brainstorming | Step 6 (design confirmed by user) | spec-reviewer |
+| domain-understanding | Domain profile confirmed | domain-understanding-reviewer |
+| market-analysis | Market analysis confirmed | market-analysis-reviewer |
+| constraint-selection | Constraints selected and confirmed | constraint-reviewer |
+| bounded-context-design | Context map confirmed | bounded-context-reviewer |
 | architecture-assessment | Characteristics confirmed | architecture-reviewer |
 | architecture-style-selection | Style selected | architecture-style-reviewer |
+| risk-storming | Risk assessment confirmed | risk-storming-reviewer |
 | quality-scenarios | Scenarios confirmed | quality-scenario-reviewer |
-| bounded-context-design | Context map confirmed | (no dedicated reviewer yet) |
+| feature-design | Feature files confirmed | feature-file-reviewer |
+| architecture-decisions | ADR written/updated | architecture-decision-reviewer |
 
 Skills that already have explicit ADR triggers (architecture-style-selection Step 7, bounded-context-design Step 8) keep them. The adr-decision-agent catches **additional** decisions the explicit triggers miss.
 

--- a/skills/bounded-context-design/SKILL.md
+++ b/skills/bounded-context-design/SKILL.md
@@ -298,6 +298,14 @@ If boundary decisions were non-obvious (e.g., "we decided to keep Billing and Ch
 - [ ] context-map.md written to project root
 - [ ] Significant boundary decisions documented as ADRs
 
+## Post-Skill Review
+
+After the context map is confirmed by the user, follow `references/post-skill-review.md`:
+1. Dispatch `adr-decision-agent` to capture architecture decisions from this dialog
+2. Dispatch `bounded-context-reviewer` with new ADR context for context map quality review
+
+Follow the Review-Loop Pattern from `agents/reviewer-protocol.md`.
+
 ## The Bottom Line
 
 Domain boundaries before architecture boundaries. If you can't name the ubiquitous language, you don't understand the boundary.

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -29,17 +29,20 @@ You MUST create a task for each of these items and complete them in order:
 6. **Present design** — in sections scaled to their complexity, get user approval after each section
 6b. **Post-design review** — follow `references/post-skill-review.md`: dispatch adr-decision-agent to scan dialog for ADR-worthy decisions (steps 4-6). Agent writes ADRs autonomously. Then dispatch spec-reviewer with new ADR context. Standard review-loop if issues found.
 6c. **UX design check** — if the feature has user-facing UI, ask: "This feature has a user interface. Shall I run the UX design process (personas, task flows, wireframes) before we continue with architecture?" If yes: invoke `superflowers:ux-design`. UX results feed into feature-design (Step 12) and writing-plans (Step 17). If no or not applicable (backend-only, CLI, API): skip.
+6d. **Market analysis** — if the feature enters a new problem space or affects competitive positioning, ask: "This feature could benefit from a market analysis to identify competitors and differentiation opportunities. Shall I run the market analysis?" If yes: invoke `superflowers:market-analysis`. Market results inform subdomain classification in bounded-context-design (Step 8). If no or not applicable (internal tooling, infrastructure, purely technical): skip.
 7. **Constraint selection** — invoke superflowers:constraint-selection to select organizational constraints relevant to this feature. Constraints inform architecture and spec. Skips automatically if no constraint repo is configured.
-8. **Bounded context design** — invoke superflowers:bounded-context-design to identify domain boundaries, classify subdomains, create context map. Builds on the domain profile from step 2. Skips automatically for single-domain projects.
+8. **Bounded context design** — invoke superflowers:bounded-context-design to identify domain boundaries, classify subdomains, create context map. Builds on the domain profile from step 2 and market analysis from step 6d (if available). Skips automatically for single-domain projects.
 9. **Architecture assessment** — invoke superflowers:architecture-assessment to identify/review architecture characteristics. Architecture informs the spec.
 10. **Architecture style selection** — invoke superflowers:architecture-style-selection to select best-fitting architecture style based on driving characteristics and generate style fitness functions. Updates architecture.md.
-11. **Quality scenarios** — invoke superflowers:quality-scenarios to create testable quality scenarios from architecture characteristics, categorized by test type.
+10b. **Risk storming** — invoke superflowers:risk-storming to identify architecture risks using parallel agent perspectives. Risk assessment informs quality scenarios (Step 11) — Red risks should have corresponding quality scenarios. Requires architecture.md from Step 10.
+11. **Quality scenarios** — invoke superflowers:quality-scenarios to create testable quality scenarios from architecture characteristics, categorized by test type. Informed by risk assessment from Step 10b — Red risks should be covered by scenarios.
 12. **Write feature files** — invoke superflowers:feature-design to create BDD acceptance criteria as Gherkin scenarios. Scenarios inform the spec.
 13. **Write design doc** — save to `docs/superflowers/specs/YYYY-MM-DD-<topic>-design.md` and commit. Spec references architecture.md, quality-scenarios.md, .feature files, and active constraints.
 14. **Spec self-review** — check for placeholders, contradictions, ambiguity, scope, architecture alignment, scenario coverage, constraint coverage (see below)
-15. **User reviews written spec** — ask user to review the spec file before proceeding
-16. **Create worktree** — invoke superflowers:using-git-worktrees to create an isolated workspace for implementation
-17. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+15. **Spec review-agent loop** — dispatch spec-reviewer agent (fresh context) to independently verify the written spec. Follow the Review-Loop Pattern from `agents/reviewer-protocol.md`. Fix issues and re-dispatch until APPROVED. Do NOT ask the user anything or proceed to the next step until the reviewer returns APPROVED.
+16. **User reviews written spec** — only after spec-reviewer has returned APPROVED: ask user to review the spec file before proceeding
+17. **Create worktree** — invoke superflowers:using-git-worktrees to create an isolated workspace for implementation
+18. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -82,34 +85,48 @@ digraph brainstorming {
     "Invoke ux-design" [shape=doublecircle, style=dashed];
     "Post-design review\n(ADR + artifact review)" -> "Feature has UI?";
     "Feature has UI?" -> "Invoke ux-design" [label="yes, user confirms"];
-    "Feature has UI?" -> "Invoke constraint-selection" [label="no / skip"];
-    "Invoke ux-design" -> "Invoke constraint-selection";
+    "Feature has UI?" -> "Market context needed?" [label="no / skip"];
+    "Invoke ux-design" -> "Market context needed?";
+    "Market context needed?" [shape=diamond];
+    "Invoke market-analysis" [shape=doublecircle, style=dashed];
+    "Market context needed?" -> "Invoke market-analysis" [label="yes, user confirms"];
+    "Market context needed?" -> "Invoke constraint-selection" [label="no / skip"];
+    "Invoke market-analysis" -> "Invoke constraint-selection";
     "Invoke constraint-selection" [shape=doublecircle];
     "Invoke constraint-selection" -> "Invoke bounded-context-design";
     "Invoke bounded-context-design" [shape=doublecircle];
     "Invoke bounded-context-design" -> "Invoke architecture-assessment";
     "Invoke architecture-style-selection" [shape=doublecircle];
     "Invoke architecture-assessment" -> "Invoke architecture-style-selection";
+    "Invoke risk-storming" [shape=doublecircle];
+    "Invoke architecture-style-selection" -> "Invoke risk-storming";
     "Invoke quality-scenarios" [shape=doublecircle];
-    "Invoke architecture-style-selection" -> "Invoke quality-scenarios";
+    "Invoke risk-storming" -> "Invoke quality-scenarios";
     "Invoke quality-scenarios" -> "Invoke feature-design";
     "Invoke feature-design" -> "Write design doc";
     "Write design doc" -> "Spec self-review\n(fix inline)";
-    "Spec self-review\n(fix inline)" -> "User reviews spec?";
+    "Dispatch spec-reviewer\n(review-agent loop)" [shape=box];
+    "Spec self-review\n(fix inline)" -> "Dispatch spec-reviewer\n(review-agent loop)";
+    "spec-reviewer APPROVED?" [shape=diamond];
+    "Dispatch spec-reviewer\n(review-agent loop)" -> "spec-reviewer APPROVED?";
+    "spec-reviewer APPROVED?" -> "Dispatch spec-reviewer\n(review-agent loop)" [label="ISSUES_FOUND\nfix & re-dispatch"];
+    "spec-reviewer APPROVED?" -> "User reviews spec?" [label="APPROVED"];
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
     "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
 }
 ```
 
 **After design approval, invoke specification skills BEFORE writing the spec:**
-1. superflowers:constraint-selection — select organizational constraints relevant to this feature (skips if no constraint repo configured)
-2. superflowers:bounded-context-design — identify domain boundaries, classify subdomains, create context map (skips automatically if single-domain project)
-3. superflowers:architecture-assessment — identify/review architecture characteristics (informed by context-map.md and active constraints if they exist)
-4. superflowers:architecture-style-selection — select best-fitting architecture style based on characteristics (context boundaries inform service/module cuts)
-5. superflowers:quality-scenarios — create testable quality scenarios from quality goals, categorized by test type
-6. superflowers:feature-design — create BDD acceptance criteria as Gherkin scenarios (uses ubiquitous language from context-map.md, considers active constraints)
-7. Then write the design doc (spec references context-map.md, architecture.md, quality-scenarios.md, .feature files, and active constraints)
-8. Then invoke writing-plans
+1. superflowers:market-analysis — understand competitive landscape and differentiation (conditional: skip for internal/technical projects)
+2. superflowers:constraint-selection — select organizational constraints relevant to this feature (skips if no constraint repo configured)
+3. superflowers:bounded-context-design — identify domain boundaries, classify subdomains, create context map (skips automatically if single-domain project; informed by market analysis if available)
+4. superflowers:architecture-assessment — identify/review architecture characteristics (informed by context-map.md and active constraints if they exist)
+5. superflowers:architecture-style-selection — select best-fitting architecture style based on characteristics (context boundaries inform service/module cuts)
+6. superflowers:risk-storming — identify architecture risks from multiple perspectives (Red risks inform quality scenarios)
+7. superflowers:quality-scenarios — create testable quality scenarios from quality goals, categorized by test type (covers Red risks from risk-storming)
+8. superflowers:feature-design — create BDD acceptance criteria as Gherkin scenarios (uses ubiquitous language from context-map.md, considers active constraints)
+9. Then write the design doc (spec references context-map.md, architecture.md, risk-assessment.md, quality-scenarios.md, .feature files, and active constraints)
+10. Then invoke writing-plans
 
 Do NOT invoke frontend-design, mcp-builder, or any other implementation skill directly.
 
@@ -170,6 +187,15 @@ If no `doc/adr/` exists: skip this step and proceed normally.
 
 - Write the validated design (spec) to `docs/superflowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
+  > Consumed by: writing-plans (Step 17), executing-plans (implementation reference)
+- Spec references:
+  - `architecture.md` > Consumed by: quality-scenarios (Step 11), feature-design (Step 12), writing-plans (Step 17)
+  - `risk-assessment.md` > Consumed by: quality-scenarios (Step 11)
+  - `quality-scenarios.md` > Consumed by: writing-plans (Step 17), fitness-functions (implementation)
+  - `.feature` files > Consumed by: writing-plans (Step 17), bdd-testing (implementation)
+  - `context-map.md` > Consumed by: architecture-assessment (Step 9), feature-design (Step 12)
+  - `market-analysis.md` > Consumed by: bounded-context-design (Step 8)
+  - Active constraints > Consumed by: architecture-assessment (Step 9), quality-scenarios (Step 11)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 
@@ -186,12 +212,24 @@ After writing the spec document, look at it with fresh eyes:
 
 Fix any issues inline. No need to re-review — just fix and move on.
 
+**Spec Review-Agent Loop (mandatory before user gate):**
+
+<HARD-GATE>
+Do NOT ask the user to review the spec, do NOT offer to proceed to writing-plans, and do NOT ask any question until the spec-reviewer agent has returned APPROVED. The review-agent loop runs automatically — no user interaction until it passes.
+</HARD-GATE>
+
+1. Dispatch `spec-reviewer` agent with the written spec file path
+2. Follow the Review-Loop Pattern from `agents/reviewer-protocol.md`:
+   - APPROVED → proceed to User Review Gate
+   - ISSUES_FOUND → fix each FAIL item, re-dispatch spec-reviewer (fresh context), repeat
+3. Only after APPROVED: proceed to the User Review Gate below
+
 **User Review Gate:**
-After the spec review loop passes, ask the user to review the written spec before proceeding:
+After the spec-reviewer has returned APPROVED, ask the user to review the written spec:
 
-> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+> "Spec written, reviewed by spec-reviewer (APPROVED), and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
-Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+Wait for the user's response. If they request changes, make them and re-run the spec review-agent loop. Only proceed once the user confirms.
 
 **Implementation:**
 

--- a/skills/domain-understanding/SKILL.md
+++ b/skills/domain-understanding/SKILL.md
@@ -218,6 +218,14 @@ Save the confirmed profile to `domain-profile.md` in the project root. Commit it
 - [ ] User has confirmed the domain profile
 - [ ] Output written to domain-profile.md
 
+## Post-Skill Review
+
+After the domain profile is confirmed by the user, follow `references/post-skill-review.md`:
+1. Dispatch `adr-decision-agent` to capture architecture decisions from this dialog
+2. Dispatch `domain-understanding-reviewer` with new ADR context for domain profile quality review
+
+Follow the Review-Loop Pattern from `agents/reviewer-protocol.md`.
+
 ## The Bottom Line
 
 Understand the domain before designing the solution. If the glossary is empty, the model is invented.

--- a/skills/market-analysis/SKILL.md
+++ b/skills/market-analysis/SKILL.md
@@ -264,6 +264,14 @@ Welche quality requirements erzwingt der Markt?
 - [ ] User has confirmed the analysis and differentiation strategy
 - [ ] Output written to market-analysis.md
 
+## Post-Skill Review
+
+After the market analysis is confirmed by the user, follow `references/post-skill-review.md`:
+1. Dispatch `adr-decision-agent` to capture architecture decisions from this dialog
+2. Dispatch `market-analysis-reviewer` with new ADR context for market analysis quality review
+
+Follow the Review-Loop Pattern from `agents/reviewer-protocol.md`.
+
 ## The Bottom Line
 
 Know your competition before you design your product. Core Subdomains are where you differentiate — everything else is table stakes.

--- a/skills/risk-storming/SKILL.md
+++ b/skills/risk-storming/SKILL.md
@@ -243,6 +243,14 @@ Trigger: [Nach Style-Selection / Manuell / Nach Feature X]
 - [ ] User has confirmed risk assessment
 - [ ] Mitigation strategies for Red risks documented with owner and timeline
 
+## Post-Skill Review
+
+After the risk assessment is confirmed by the user, follow `references/post-skill-review.md`:
+1. Dispatch `adr-decision-agent` to capture architecture decisions from this dialog
+2. Dispatch `risk-storming-reviewer` with new ADR context for risk assessment quality review
+
+Follow the Review-Loop Pattern from `agents/reviewer-protocol.md`.
+
 ## The Bottom Line
 
 Consensus on risk areas prevents surprise failures. If the team hasn't agreed on what's Red, nobody owns the mitigation.


### PR DESCRIPTION
## Context

Teil der „Review Agents"-Initiative: frische Reviewer-Agents für die frühen Chain-Skills, Einbindung von market-analysis & risk-storming in den brainstorming-Workflow, plus der neue constraint-clarifier-Agent. Drei thematisch getrennte Commits.

## Commits

1. **Reviewer-Agents + Post-Skill-Review-Verdrahtung** — neue Agents (domain-understanding, market-analysis, bounded-context, risk-storming), „Post-Skill Review"-Sektionen in den vier Skills, erweiterte Registry in `references/post-skill-review.md`.
2. **brainstorming-Workflow-Integration** — market-analysis (Step 6d) & risk-storming (Step 10b) in die Kette eingebunden, verpflichtender `spec-reviewer`-HARD-GATE-Loop vor dem User-Gate, „Consumed by"-Marker, Schritt-Neunummerierung.
3. **constraint-clarifier-Agent** — neuer Agent (Single-Agent-Routing, Strict Mode), Design-Spec unter `docs/superflowers/specs/`, Plugin-Meta-ADRs unter `doc/adr/` (ADR-001/002/003).

## Hinweis (offen, kein Blocker)

`references/post-skill-review.md` referenziert bereits Reviewer, die noch nicht existieren (`constraint-reviewer`, `feature-file-reviewer`, `architecture-decision-reviewer`) — Teil der laufenden 12-Agent-Initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)