### PR TITLE
cleanup: verification-type canon fix + unify version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superflowers",
       "source": ".",
       "description": "Composable skills for DDD, architecture, and BDD workflows",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superflowers",
   "description": "Composable skills for DDD, architecture, and BDD workflows — fork of Superpowers by Jesse Vincent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Florian"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "superflowers",
   "displayName": "Superflowers",
   "description": "Custom fork of superflowers: skills library for Claude Code",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -13,7 +13,11 @@
       "node_modules",
       ".git",
       ".version-bump.json",
-      "scripts/bump-version.sh"
+      "scripts/bump-version.sh",
+      "-workspace",
+      "featurebench-eval",
+      ".venv",
+      "package-lock.json"
     ]
   }
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "superflowers",
   "description": "Custom fork of superflowers: skills library for Claude Code",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superflowers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": ".opencode/plugins/superflowers.js"
 }

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -35,7 +35,7 @@ You MUST create a task for each of these items and complete them in order:
 9. **Architecture assessment** — invoke superflowers:architecture-assessment to identify/review architecture characteristics. Architecture informs the spec.
 10. **Architecture style selection** — invoke superflowers:architecture-style-selection to select best-fitting architecture style based on driving characteristics and generate style fitness functions. Updates architecture.md.
 10b. **Risk storming** — invoke superflowers:risk-storming to identify architecture risks using parallel agent perspectives. Risk assessment informs quality scenarios (Step 11) — Red risks should have corresponding quality scenarios. Requires architecture.md from Step 10.
-11. **Quality scenarios** — invoke superflowers:quality-scenarios to create testable quality scenarios from architecture characteristics, categorized by test type. Informed by risk assessment from Step 10b — Red risks should be covered by scenarios.
+11. **Quality scenarios** — invoke superflowers:quality-scenarios to create testable quality scenarios from architecture characteristics, categorized by verification type. Informed by risk assessment from Step 10b — Red risks should be covered by scenarios.
 12. **Write feature files** — invoke superflowers:feature-design to create BDD acceptance criteria as Gherkin scenarios. Scenarios inform the spec.
 13. **Write design doc** — save to `docs/superflowers/specs/YYYY-MM-DD-<topic>-design.md` and commit. Spec references architecture.md, quality-scenarios.md, .feature files, and active constraints.
 14. **Spec self-review** — check for placeholders, contradictions, ambiguity, scope, architecture alignment, scenario coverage, constraint coverage (see below)
@@ -123,7 +123,7 @@ digraph brainstorming {
 4. superflowers:architecture-assessment — identify/review architecture characteristics (informed by context-map.md and active constraints if they exist)
 5. superflowers:architecture-style-selection — select best-fitting architecture style based on characteristics (context boundaries inform service/module cuts)
 6. superflowers:risk-storming — identify architecture risks from multiple perspectives (Red risks inform quality scenarios)
-7. superflowers:quality-scenarios — create testable quality scenarios from quality goals, categorized by test type (covers Red risks from risk-storming)
+7. superflowers:quality-scenarios — create testable quality scenarios from quality goals, categorized by verification type (covers Red risks from risk-storming)
 8. superflowers:feature-design — create BDD acceptance criteria as Gherkin scenarios (uses ubiquitous language from context-map.md, considers active constraints)
 9. Then write the design doc (spec references context-map.md, architecture.md, risk-assessment.md, quality-scenarios.md, .feature files, and active constraints)
 10. Then invoke writing-plans

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -34,7 +34,7 @@ For each task:
 After all tasks complete and verified:
 - If .feature files exist: verify ALL BDD scenarios pass (superflowers:bdd-testing)
 - If architecture.md exists: verify ALL fitness functions pass (superflowers:fitness-functions)
-- If quality-scenarios.md exists: verify ALL quality scenarios have passing tests matching their test type
+- If quality-scenarios.md exists: verify ALL quality scenarios have passing tests matching their verification type
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superflowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice

--- a/skills/quality-scenarios/SKILL.md
+++ b/skills/quality-scenarios/SKILL.md
@@ -261,7 +261,7 @@ Generated from architecture.md quality goals using ATAM.
 - [ ] Every characteristic with a concrete goal in architecture.md has at least one scenario
 - [ ] Top 3 characteristics have 2-3 scenarios each (different environments)
 - [ ] Every scenario has a concrete response measure (number, threshold, or observable outcome)
-- [ ] Test types are diverse (not all fitness functions, not all load tests)
+- [ ] Verification types are diverse (not all fitness functions, not all load tests)
 - [ ] Style fitness functions from architecture.md are NOT duplicated
 - [ ] Tradeoffs between conflicting characteristics are documented
 - [ ] User has reviewed and approved the scenarios
@@ -281,4 +281,4 @@ Every architecture characteristic needs a concrete, measurable quality scenario.
 
 ## Reference Files
 
-- `references/test-type-guide.md` — Detailed decision tree for classifying scenarios into verification types, with examples per characteristic and language-specific tooling recommendations
+- `references/verification-type-guide.md` — Detailed decision tree for classifying scenarios into verification types, with examples per characteristic and language-specific tooling recommendations

--- a/skills/quality-scenarios/references/verification-type-guide.md
+++ b/skills/quality-scenarios/references/verification-type-guide.md
@@ -1,6 +1,6 @@
-# Test Type Decision Guide
+# Verification Type Decision Guide
 
-How to classify a quality scenario into the right test type.
+How to classify a quality scenario into the right verification type.
 
 ## Decision Tree
 
@@ -34,21 +34,21 @@ Does this scenario require HUMAN JUDGMENT?
 ## Examples Per Characteristic
 
 ### Performance
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | API < 200ms p95 | 1000 users hit /search concurrently | load-test | Needs running system under volume |
 | DB query < 50ms | Single query with 1M rows | integration-test | Needs real DB but not volume stress |
 | Algorithm O(n log n) | Sort 100k items in < 100ms | unit-test | Single component, no dependencies |
 
 ### Availability
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | 99.9% uptime | Health check returns 200 every 30s | integration-test | Needs running system |
 | Survives node failure | Kill 1 of 3 replicas, system continues | chaos-test | Resilience under failure |
 | Graceful degradation | External API timeout, return cached data | integration-test | Cross-component behavior |
 
 ### Security
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | No known CVEs | Dependency scan finds 0 critical CVEs | fitness-function | Static analysis, no running system |
 | RBAC enforced | Unauthorized user gets 403 | integration-test | Needs auth system running |
@@ -56,35 +56,35 @@ Does this scenario require HUMAN JUDGMENT?
 | Penetration test | OWASP Top 10 audit | manual-review | Requires expert judgment |
 
 ### Scalability
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | Handle 100k concurrent | Ramp from 1k to 100k users | load-test | Volume stress |
 | Horizontal scaling | Add 3 nodes, throughput increases linearly | load-test + chaos-test | Volume + infrastructure |
 | No single point of failure | Any single component can fail | chaos-test | Resilience |
 
 ### Testability
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | > 80% coverage | Coverage report shows > 80% | fitness-function | Static metric |
 | All modules testable independently | Each module has standalone test suite | fitness-function | Structural check |
 | Integration tests exist for all APIs | Every API endpoint has at least 1 test | fitness-function | Structural check |
 
 ### Maintainability
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | Cyclomatic complexity < 10 | No function exceeds threshold | fitness-function | Static analysis |
 | No function > 50 lines | LOC check per function | fitness-function | Static analysis |
 | New dev productive in 1 week | Developer onboarding review | manual-review | Subjective |
 
 ### Data Integrity
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | No data loss during failures | Kill DB during write, verify all data persists | chaos-test | Resilience |
 | Consistent across replicas | Write to primary, read from replica within 5s | integration-test | Cross-component |
 | Referential integrity | Delete parent, verify cascade/reject | unit-test or integration-test | Depends on where enforced |
 
 ### Usability / Accessibility
-| Goal | Scenario | Test Type | Why |
+| Goal | Scenario | Verification Type | Why |
 |------|----------|-----------|-----|
 | WCAG 2.1 AA | Automated accessibility scan | fitness-function (partial) + manual-review | Automated catches ~30%, human catches the rest |
 | Mobile responsive | All pages render correctly on 375px viewport | integration-test | Needs running UI |
@@ -92,7 +92,7 @@ Does this scenario require HUMAN JUDGMENT?
 
 ## Language-Specific Tooling
 
-| Test Type | JS/TS | Java/Kotlin | Python | Go |
+| Verification Type | JS/TS | Java/Kotlin | Python | Go |
 |-----------|-------|-------------|--------|-----|
 | unit-test | Jest, Vitest | JUnit 5 | pytest | go test |
 | integration-test | Supertest, Playwright | Spring Boot Test, Testcontainers | pytest + httpx, Testcontainers | go test + testcontainers |

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -109,10 +109,10 @@ Skip any step = lying, not verifying
 
 **Quality Scenarios (when quality-scenarios.md exists):**
 ```
-✅ [Check each scenario by test type] [See: unit tests pass, integration tests pass, load test meets threshold] "All quality scenarios verified"
+✅ [Check each scenario by verification type] [See: unit tests pass, integration tests pass, load test meets threshold] "All quality scenarios verified"
 ❌ "Tests pass" (which tests? which scenarios?) / "Quality looks good"
 ```
-Quality scenarios define different test types. Verify each type ran:
+Quality scenarios define different verification types. Verify each type ran:
 - unit-test scenarios: covered by unit test suite
 - integration-test scenarios: covered by integration test suite
 - load-test scenarios: load test results meet response measures

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -40,7 +40,7 @@ If specification skills were used before this plan, the plan MUST reference thei
 
 **quality-scenarios** (quality-scenarios.md exists):
 - Plan tasks should include test implementations for each quality scenario
-- Categorize test tasks by the **test type** defined in quality-scenarios.md (unit-test, integration-test, load-test, chaos-test, fitness-function, manual-review)
+- Categorize test tasks by the **verification type** defined in quality-scenarios.md (unit-test, integration-test, load-test, chaos-test, fitness-function, manual-review)
 - Group test implementation tasks by type: unit tests first (fastest feedback), then integration, then load/chaos tests
 - Reference tradeoffs from quality-scenarios.md when they affect implementation choices
 - Do NOT create test tasks for scenarios that overlap with style fitness functions (already covered)
@@ -106,7 +106,7 @@ This structure informs the task decomposition. Each task should produce self-con
 
 **Style Fitness Functions:** [List style-specific structural checks from architecture.md, or "N/A"]
 
-**Quality Scenarios:** [List quality scenarios by test type from quality-scenarios.md, or "N/A"]
+**Quality Scenarios:** [List quality scenarios by verification type from quality-scenarios.md, or "N/A"]
 
 **Active ADRs:** [List active architecture decisions from doc/adr/ that affect this implementation, or "N/A"]
 


### PR DESCRIPTION
Zwei abgestimmte Aufräum-Punkte nach dem v5.1.0-Sync.

## 1. Kanon-Fix: 'test type' → 'verification type'
Systemische Korrektur der Quality-Scenario-Klassifikation auf den kanonischen Begriff (CLAUDE.md § Terminology):
- `verification-before-completion`, `brainstorming`, `executing-plans`, `writing-plans`, `quality-scenarios` (inkl. Checklisten-Item "Verification types are diverse")
- Datei umbenannt: `references/test-type-guide.md` → `verification-type-guide.md` + Referenz angepasst
- **Unberührt:** die absichtlichen `test type`-Meta-Referenzen in `upstream-sync` (Violation-Detektor + Terminologie-Note)

## 2. Version vereinheitlicht auf 1.1.0
Behebt die Drift (1.0.0 vs 0.1.0) via neuem `scripts/bump-version.sh`. 1.1.0 markiert die v5.1.0-Sync-Integration. Alle 5 Manifeste jetzt synchron; `.version-bump.json` Audit-Excludes erweitert (gitignorierte Workspace/venv-Treffer).

`bump-version.sh --check` → all in sync at 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)