### PR TITLE
skills: Live-Evidenz-Gate gegen die Verifikations-Illusion (Retro #1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superflowers",
       "source": ".",
       "description": "Composable skills for DDD, architecture, and BDD workflows",
-      "version": "1.3.1"
+      "version": "1.3.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superflowers",
   "description": "Composable skills for DDD, architecture, and BDD workflows — fork of Superpowers by Jesse Vincent",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Florian"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "superflowers",
   "displayName": "Superflowers",
   "description": "Custom fork of superflowers: skills library for Claude Code",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "superflowers",
   "description": "Custom fork of superflowers: skills library for Claude Code",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superflowers",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "main": ".opencode/plugins/superflowers.js"
 }

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -35,6 +35,7 @@ After all tasks complete and verified:
 - If .feature files exist: verify ALL BDD scenarios pass (superflowers:bdd-testing)
 - If architecture.md exists: verify ALL fitness functions pass (superflowers:fitness-functions)
 - If quality-scenarios.md exists: verify ALL quality scenarios have passing tests matching their verification type
+- **Live evidence (beyond green suites):** drive the real system once — start the real backend/process, run one real happy-path end-to-end (on the real target device where a UI ships), observe actual behavior. Green tests against mocks prove wiring, not reality. No live run → not done.
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superflowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -28,6 +28,8 @@ npm test / cargo test / pytest / go test ./...
 - If .feature files exist: verify ALL BDD scenarios pass (superflowers:bdd-testing)
 - If architecture.md exists: verify ALL fitness functions pass (superflowers:fitness-functions)
 
+**Live evidence (beyond green suites):** drive the real system once — start the real backend/process, run one real happy-path end-to-end (on the real target device where a UI ships), observe actual behavior. Green tests against mocks prove wiring, not reality. No live run → not done.
+
 **If ANY verification fails:**
 ```
 Verification failing. Must fix before completing:

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -106,8 +106,9 @@ After the final code review and BEFORE finishing-a-development-branch, run speci
    - Verify EVERY characteristic marked "Fitness Function: Yes" has an implementation
    - Verify EVERY style fitness function has an implementation
    - Run ALL fitness functions → all must pass
-3. ALL checks must pass — partial passage is failure
-4. If ANY check fails: re-dispatch implementer to fix, then re-run ALL checks from step 1
+3. **Live evidence (beyond green suites):** drive the real system once — start the real backend/process, run one real happy-path end-to-end (on the real target device where a UI ships), observe actual behavior. Green tests against mocks prove wiring, not reality. No live run → not done.
+4. ALL checks must pass — partial passage is failure
+5. If ANY check fails: re-dispatch implementer to fix, then re-run ALL checks from step 1
 
 <HARD-GATE>
 Follow the Review-Loop Pattern from agents/reviewer-protocol.md:


### PR DESCRIPTION
## Kontext
Erste von 8 priorisierten Verbesserungen aus der Superflowers-Retrospektive über 5 externe Projekte
(tinder-cli, mtg-worldmodel, mieterrecht, ontocraft, architecture-patterns). Vollanalyse:
`~/.claude/plans/in-einigen-anderen-projekten-parsed-walrus.md`.

## Problem (P0 — Verifikations-Illusion)
Die Vollzugs-Gates fordern nur, dass BDD-Szenarien / Fitness-Functions **grün** sind. Grün gegen ein
gemocktes Backend erfüllt das wörtlich — genau so meldete mtg-worldmodel „fertig" bei 88 grünen
jsdom-Szenarien, während echte Auth-/Timeout-/CSS-Bugs auslieferten. Belege: `fitness-functions` lief 0×,
`bdd-testing` 1×, `verification-before-completion` 0× über alle 5 Projekte — das Konzept „einmal gegen das
echte System laufen" existierte in **keinem** Gate.

## Änderung
Eine **wortgleiche, artefakt-unabhängige** Zeile in die drei Vollzugs-Gates, die tatsächlich feuern:
- `subagent-driven-development` (Specification Verification Gate) — fängt das vorzeitige „fertig" im Loop
- `executing-plans` (Verifikations-Schritt)
- `finishing-a-development-branch` (Verifikations-Schritt, gemeinsamer Endpunkt)

> **Live evidence (beyond green suites):** drive the real system once — start the real backend/process,
> run one real happy-path end-to-end (on the real target device where a UI ships), observe actual behavior.
> Green tests against mocks prove wiring, not reality. No live run → not done.

Bewusst schlank (Keywords tragen die Methodik), nicht in die selten aufgerufenen Verifikations-Skills.

## Verifikation (RED/GREEN)
Parallele Pressure-Agents, Szenario „34/34 Unit + 88/88 BDD grün, aber Backend gemockt":
- **RED** (ohne Zeile): SDD-Gate → `DONE`, finishing → `PROCEED` (meldet fertig, wie mtg)
- **GREEN** (mit Zeile): SDD-Gate → `NOT_DONE`, finishing → `BLOCKED` (verlangt echten Live-Lauf)

Version 1.3.1 → 1.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)